### PR TITLE
Add overrides for rules

### DIFF
--- a/node.js
+++ b/node.js
@@ -15,5 +15,19 @@ module.exports = {
         'node/callback-return': 'error',
         'node/prefer-promises/fs': 'error',
         'node/prefer-promises/dns': 'error'
-      }
+    },
+    overrides: [
+        {
+          files: ['*.ts'],
+          rules: {
+            'node/no-missing-import': [
+                'error',
+                {
+                    tryExtensions: ['.ts', '.js', '.json', '.node']
+                }
+            ],
+            'node/no-unsupported-features/es-syntax': 'off'
+          }
+        }
+    ]
 };

--- a/typescript.js
+++ b/typescript.js
@@ -113,7 +113,7 @@ module.exports = {
             }
         },
         {
-            files: ['*.{spec, test, tests}.*', '**/__tests__/**'],
+            files: ['*.{spec, test, tests, stories}.*', '**/__tests__/**', '**/__stories__/**'],
             rules: {
                 '@typescript-eslint/no-magic-numbers': 'off',
                 '@typescript-eslint/unbound-method': 'off'

--- a/typescript.js
+++ b/typescript.js
@@ -111,6 +111,13 @@ module.exports = {
                 '@typescript-eslint/switch-exhaustiveness-check': 'error',
                 '@typescript-eslint/unified-signatures': 'error'
             }
+        },
+        {
+            files: ['*.{spec, test, tests}.*', '**/__tests__/**'],
+            rules: {
+                '@typescript-eslint/no-magic-numbers': 'off',
+                '@typescript-eslint/unbound-method': 'off'
+            }
         }
     ]
 };


### PR DESCRIPTION
Выключил в тестах: 
`@typescript-eslint/no-magic-numbers` - заставляет плодить 100500 переменных, которые снижают читаемость тестов
`@typescript-eslint/unbound-method` - не даёт использовать expect на методы классов

Так же для `.ts` файлов: 
Выключил `node/no-unsupported-features/es-syntax` - не даёт использовать импорты, а TS в любом случае компиллится 
Расширил `node/no-missing-import`, чтобы можно было юзать импорты(по дефолту там нет .ts в списке расширений)