### PR TITLE
feat(best-practices): remove noise no-magic-numbers rule

### DIFF
--- a/configs/best-practices.js
+++ b/configs/best-practices.js
@@ -36,14 +36,6 @@ module.exports = {
         'no-labels': 'error',
         'no-lone-blocks': 'error',
         'no-loop-func': 'error',
-        'no-magic-numbers': [
-            'warn',
-            {
-                ignore: [-1, 0, 1],
-                ignoreArrayIndexes: true,
-                ignoreDefaultValues: true
-            }
-        ],
         'no-multi-spaces': 'warn',
         'no-new-func': 'error',
         'no-new-wrappers': 'error',
@@ -73,13 +65,5 @@ module.exports = {
                 exceptRange: true
             }
         ]
-    },
-    overrides: [
-        {
-            files: ['*.{spec, test, tests, stories}.*', '**/__tests__/**', '**/__stories__/**'],
-            rules: {
-                'no-magic-numbers': 'off'
-            }
-        }
-    ]
+    }
 };


### PR DESCRIPTION
`no-magic-numbers`  шумное и раздражающее правило, которое например срабатывает на декораторы `class-validator`

```ts
import {ApiPropertyOptional} from "@nestjs/swagger";
import {IsInt, Max, Min} from "class-validator";

import {TransformToNumber} from "~/src/infrastructure";

export class ListQueryDto {
  @TransformToNumber()
  @IsInt()
  @Min(1)
  @Max(100) // <-- ругается вот тут
  @ApiPropertyOptional()
  public readonly pageSize: number = 10;
}
```