### PR TITLE
fix(sonarjs): fix tests mask

### DIFF
--- a/configs/sonarjs.js
+++ b/configs/sonarjs.js
@@ -13,7 +13,7 @@ module.exports = {
     },
     overrides: [
         {
-            files: ['*.{spec, test, tests}.*', '**/__tests__/**', '**/__stories__/**', '**/__fixtures__/**'],
+            files: ['*{spec, test, tests}.*', '**/__tests__/**', '**/__stories__/**', '**/__fixtures__/**'],
             rules: {
                 'sonarjs/no-duplicate-string': 'off',
                 'sonarjs/no-identical-functions': 'off'


### PR DESCRIPTION
Пофиксил маску тестов, чтобы она подходила под интеграционные тесты NestJS, которые имеют вид `.e2e-spec.ts$` (см. [тут](https://github.com/nestjs/typescript-starter/blob/master/test/jest-e2e.json#L5))