### PR TITLE
feat(jest): fix jest config

### DIFF
--- a/jest-style-frontend.js
+++ b/jest-style-frontend.js
@@ -1,7 +1,7 @@
 module.exports = {
     overrides: [
         {
-            files: ['*{spec, test, tests}.*'],
+            files: ['*{spec, test, tests}.*', '**/__tests__/**'],
             rules: {
                 // eslint-plugin-jest Rules
                 'jest/consistent-test-it': [

--- a/jest.js
+++ b/jest.js
@@ -1,29 +1,14 @@
 module.exports = {
-    env: {
-        'jest/globals': true
-    },
-    extends: ['plugin:jest/recommended'],
-    plugins: ['jest'],
-    parserOptions: {
-        ecmaVersion: 2018,
-        sourceType: 'module'
-    },
-    settings: {
-        jest: {
-            version: 26
-        }
-    },
     overrides: [
         {
-            files: ['*.{spec, test, tests}.*', '**/__tests__/**'],
+            files: ['*{spec, test, tests}.*', '**/__tests__/**'],
+            extends: ['plugin:jest/recommended'],
+            env: {
+                'jest/globals': true
+            },
+            plugins: ['jest'],
             rules: {
-                'jest/consistent-test-it': [
-                    'error',
-                    {
-                        fn: 'test',
-                        withinDescribe: 'test'
-                    }
-                ],
+                // eslint-plugin-jest
                 'jest/no-duplicate-hooks': 'error',
                 'jest/no-test-return-statement': 'error',
                 'jest/prefer-called-with': 'warn',


### PR DESCRIPTION
Пофиксил маску тестов, чтобы она подходила под интеграционные тесты NestJS, которые имеют вид `.e2e-spec.ts$` (см. [тут](https://github.com/nestjs/typescript-starter/blob/master/test/jest-e2e.json#L5))
Убрал parserOptions, т.к. эти они должны быть в конфигах javascript и typescript.
Убрал settings, т.к. версия jest умеет определяться автоматом.
Вынес `jest/consistent-test-it` в стилистические правила (см #14 и #15).
