### PR TITLE
feat(node): fix node config

### DIFF
--- a/node.js
+++ b/node.js
@@ -3,31 +3,31 @@ module.exports = {
         node: true
     },
     extends: ['plugin:node/recommended'],
-    plugins: ['node'],
     rules: {
-        'node/no-sync': 'error',
+        // eslint-plugin-node Possible Errors
+        'node/handle-callback-err': 'error',
         'node/no-new-require': 'error',
         'node/no-path-concat': 'error',
-        'node/handle-callback-err': 'error',
-        'node/global-require': 'error',
-        'node/file-extension-in-import': ['warn', 'never'],
-        'node/exports-style': 'error',
+        // eslint-plugin-node Stylistic Issues
         'node/callback-return': 'error',
-        'node/prefer-promises/fs': 'error',
-        'node/prefer-promises/dns': 'error'
+        'node/exports-style': 'error',
+        'node/file-extension-in-import': ['warn', 'never'],
+        'node/global-require': 'error',
+        'node/no-sync': 'error',
+        'node/prefer-promises/dns': 'error',
+        'node/prefer-promises/fs': 'error'
     },
     overrides: [
         {
-          files: ['*.ts'],
-          rules: {
-            'node/no-missing-import': [
-                'error',
-                {
-                    tryExtensions: ['.ts', '.js', '.json', '.node']
-                }
-            ],
-            'node/no-unsupported-features/es-syntax': 'off'
-          }
+            files: ['*.ts'],
+            rules: {
+                // eslint-plugin-node Possible Errors
+                'node/no-missing-import': 'off', // unnecessary for TypeScript
+                'node/no-unpublished-import': 'off', // doesn't support import types from devDependencies
+                'node/no-unsupported-features/es-syntax': 'off', // unnecessary for TypeScript
+                // eslint-plugin-node Stylistic Issues
+                'node/file-extension-in-import': 'off' // unnecessary for TypeScript
+            }
         }
     ]
 };


### PR DESCRIPTION
Правила разбиты на категории и отсортированы так, как это сделано в их офф. документации.
Для TypeScript отключил правила `node/no-missing-import`, `node/no-unpublished-import`, `node/file-extension-in-import`.
