### PR TITLE
feat(typescript): fix typescript config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -879,6 +879,18 @@
         }
       }
     },
+    "eslint-import-resolver-typescript": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.4.0.tgz",
+      "integrity": "sha512-useJKURidCcldRLCNKWemr1fFQL1SzB3G4a0li6lFGvlc5xGe1hY343bvG07cbpCzPuM/lK19FIJB3XGFSkplA==",
+      "requires": {
+        "debug": "^4.1.1",
+        "glob": "^7.1.6",
+        "is-glob": "^4.0.1",
+        "resolve": "^1.17.0",
+        "tsconfig-paths": "^3.9.0"
+      }
+    },
     "eslint-module-utils": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@typescript-eslint/eslint-plugin": "^4.3.0",
     "@typescript-eslint/parser": "^4.3.0",
     "eslint": "^7.10.0",
+    "eslint-import-resolver-typescript": "^2.4.0",
     "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.0.2",

--- a/typescript.js
+++ b/typescript.js
@@ -1,19 +1,5 @@
 module.exports = {
-    extends: [
-        'eslint:recommended',
-        './configs/best-practices.js',
-        './configs/ecmascript-6.js',
-        './configs/errors.js',
-        './configs/variables.js',
-        './configs/import.js'
-    ],
-    parser: '@typescript-eslint/parser',
-    parserOptions: {
-        ecmaVersion: 2018,
-        sourceType: 'module'
-    },
-    plugins: ['@typescript-eslint'],
-    reportUnusedDisableDirectives: true,
+    extends: ['./javascript.js'],
     overrides: [
         {
             files: ['*.ts', '*.tsx'],
@@ -23,7 +9,28 @@ module.exports = {
                 'plugin:@typescript-eslint/recommended-requiring-type-checking',
                 'plugin:import/typescript'
             ],
+            parser: '@typescript-eslint/parser',
+            parserOptions: {
+                ecmaVersion: 2019,
+                sourceType: 'module',
+                project: './tsconfig.json'
+            },
+            plugins: ['@typescript-eslint'],
+            settings: {
+                'import/resolver': {
+                    typescript: {}
+                }
+            },
             rules: {
+                // ESLint Best Practices
+                'class-methods-use-this': 'off', // TODO: https://github.com/typescript-eslint/typescript-eslint/issues/1103
+                'consistent-return': 'off', // TODO: https://github.com/typescript-eslint/typescript-eslint/issues/1277
+                'default-case': 'off', // unnecessary for TypeScript
+                // eslint-plugin-import Static analysis
+                'import/default': 'off', // TODO: https://github.com/benmosher/eslint-plugin-import/issues/1908
+                // eslint-plugin-import Helpful warnings
+                'import/no-named-as-default-member': 'off', // TODO: don't work with esModuleInterop
+                // @typescript-eslint/eslint-plugin Supported Rules
                 '@typescript-eslint/ban-ts-comment': 'warn',
                 '@typescript-eslint/consistent-type-assertions': [
                     'error',
@@ -43,31 +50,7 @@ module.exports = {
                     }
                 ],
                 '@typescript-eslint/explicit-module-boundary-types': 'error',
-                '@typescript-eslint/naming-convention': [
-                    'warn',
-                    {
-                        selector: 'interface',
-                        format: ['PascalCase'],
-                        prefix: ['I']
-                    },
-                    {
-                        selector: 'typeAlias',
-                        format: ['PascalCase'],
-                        prefix: ['T']
-                    },
-                    {
-                        selector: 'enum',
-                        format: ['PascalCase']
-                    },
-                    {
-                        selector: 'enumMember',
-                        format: ['PascalCase']
-                    }
-                ],
                 '@typescript-eslint/no-confusing-non-null-assertion': 'error',
-                'no-dupe-class-members': 'off',
-                '@typescript-eslint/no-dupe-class-members': 'error',
-                '@typescript-eslint/no-empty-function': 'warn',
                 '@typescript-eslint/no-empty-interface': [
                     'warn',
                     {
@@ -77,21 +60,6 @@ module.exports = {
                 '@typescript-eslint/no-explicit-any': 'error',
                 '@typescript-eslint/no-floating-promises': 'warn',
                 '@typescript-eslint/no-invalid-void-type': 'error',
-                'no-magic-numbers': 'off',
-                '@typescript-eslint/no-magic-numbers': [
-                    'warn',
-                    {
-                        ignore: [-1, 0, 1],
-                        ignoreArrayIndexes: true,
-                        ignoreDefaultValues: true,
-                        ignoreEnums: true,
-                        ignoreNumericLiteralTypes: true,
-                        ignoreReadonlyClassProperties: true
-                    }
-                ],
-                'no-shadow': 'off',
-                '@typescript-eslint/no-shadow': 'error',
-                '@typescript-eslint/no-throw-literal': 'error',
                 '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'warn',
                 '@typescript-eslint/no-unnecessary-condition': 'warn',
                 '@typescript-eslint/no-unnecessary-type-arguments': 'warn',
@@ -106,16 +74,22 @@ module.exports = {
                 '@typescript-eslint/prefer-string-starts-ends-with': 'warn',
                 '@typescript-eslint/prefer-ts-expect-error': 'error',
                 '@typescript-eslint/require-array-sort-compare': 'error',
-                'no-return-await': 'off',
-                '@typescript-eslint/return-await': 'error',
                 '@typescript-eslint/switch-exhaustiveness-check': 'error',
-                '@typescript-eslint/unified-signatures': 'error'
+                '@typescript-eslint/unified-signatures': 'error',
+                // @typescript-eslint/eslint-plugin Extension Rules
+                'no-dupe-class-members': 'off',
+                '@typescript-eslint/no-dupe-class-members': 'error',
+                '@typescript-eslint/no-empty-function': 'warn',
+                'no-shadow': 'off',
+                '@typescript-eslint/no-shadow': 'error',
+                '@typescript-eslint/no-throw-literal': 'error',
+                'no-return-await': 'off',
+                '@typescript-eslint/return-await': 'error'
             }
         },
         {
-            files: ['*.{spec, test, tests, stories}.*', '**/__tests__/**', '**/__stories__/**'],
+            files: ['*{spec, test, tests, stories}.*', '**/__tests__/**', '**/__stories__/**'],
             rules: {
-                '@typescript-eslint/no-magic-numbers': 'off',
                 '@typescript-eslint/unbound-method': 'off'
             }
         }


### PR DESCRIPTION
- Правила разбиты на категории и отсортированы так, как это сделано в их офф. документации
- Добавил resolver чтобы import плагин не ругался на алиасы путей вида `~/src/components/Button`
- Пофиксил typescript парсер в чтобы javascript и typescript файлы могли использоваться совместно в одном проекте
- ecmaVersion поднялась до 2019, что соответствует Node.js 12 LTS
- Отключил `no-magic-numbers`, см. #9
- Пофиксил маску тестов, чтобы она подходила под интеграционные тесты NestJS, которые имеют вид `.e2e-spec.ts$` (см. [тут](https://github.com/nestjs/typescript-starter/blob/master/test/jest-e2e.json#L5))
- Отключил правила которые не работают должным образом: `class-methods-use-this`, `consistent-return`, `default-case`, `import/default`, `import/no-named-as-default-member`
- Вынес `@typescript-eslint/naming-convention` в стилистические правила (см #14 и #15 )