### PR TITLE
feat(header-apache-2.0): add header-apache-2.0 config

### DIFF
--- a/header-apache-2.0.js
+++ b/header-apache-2.0.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+
+const pkgDir = require('pkg-dir');
+
+const pjson = JSON.parse(fs.readFileSync(path.join(pkgDir.sync(), 'package.json'), 'utf8'));
+
+const year = new Date().getUTCFullYear();
+const copyright = pjson.copyright || pjson.author;
+
+module.exports = {
+    plugins: ['header'],
+    rules: {
+        'header/header': [
+            'error',
+            'block',
+            [
+                ``,
+                {
+                    pattern: ` \\* Copyright \\d{4} ${copyright}`,
+                    template: ` * Copyright ${year} ${copyright}`
+                },
+                ` *`,
+                ` * Licensed under the Apache License, Version 2.0 (the "License");`,
+                ` * you may not use this file except in compliance with the License.`,
+                ` * You may obtain a copy of the License at`,
+                ` *`,
+                ` *     http://www.apache.org/licenses/LICENSE-2.0`,
+                ` *`,
+                ` * Unless required by applicable law or agreed to in writing, software`,
+                ` * distributed under the License is distributed on an "AS IS" BASIS,`,
+                ` * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.`,
+                ` * See the License for the specific language governing permissions and`,
+                ` * limitations under the License.`,
+                ` `
+            ],
+            2
+        ]
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1375,6 +1375,11 @@
         "string-natural-compare": "^3.0.1"
       }
     },
+    "eslint-plugin-header": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
+      "integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg=="
+    },
     "eslint-plugin-import": {
       "version": "2.22.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
@@ -2009,6 +2014,17 @@
         "please-upgrade-node": "^3.2.0",
         "slash": "^3.0.0",
         "which-pm-runs": "^1.0.0"
+      },
+      "dependencies": {
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        }
       }
     },
     "ignore": {
@@ -2672,12 +2688,46 @@
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pkg-dir": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+      "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
       "requires": {
-        "find-up": "^4.0.0"
+        "find-up": "^5.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        }
       }
     },
     "please-upgrade-node": {
@@ -3364,6 +3414,11 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
       "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
       "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@typescript-eslint/parser": "^4.3.0",
     "eslint": "^7.10.0",
     "eslint-plugin-flowtype": "^5.2.0",
+    "eslint-plugin-header": "^3.1.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.0.2",
     "eslint-plugin-jest-dom": "^3.3.0",
@@ -56,6 +57,7 @@
     "eslint-plugin-react-hooks": "^4.1.2",
     "eslint-plugin-sonarjs": "^0.5.0",
     "eslint-plugin-testing-library": "^3.10.1",
-    "eslint-plugin-unicorn": "^33.0.1"
+    "eslint-plugin-unicorn": "^33.0.1",
+    "pkg-dir": "^5.0.0"
   }
 }


### PR DESCRIPTION
- Добавил правило для автосоздания заголовка с лицензией Apache 2.0 в начале каждого файла с иходным кодом.
- В качестве даты берется текущий год по UTC
- В качетсве владельца прав берется поле `copyright` или `author` из `package.json`, который лежит рядом с `.eslintrc` файлом