### PR TITLE
Добавил plugin:react/jsx-runtime

### DIFF
--- a/configs/react.js
+++ b/configs/react.js
@@ -2,7 +2,7 @@ module.exports = {
     env: {
         browser: true
     },
-    extends: ['plugin:react/recommended'],
+    extends: ['plugin:react/recommended', 'plugin:react/jsx-runtime'],
     parserOptions: {
         ecmaFeatures: {
             jsx: true


### PR DESCRIPTION
Начиная с 17 версии `import React from 'react'` в jsx файлах необязательный

> If you are using the [new JSX transform from React 17](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports), extend [react/jsx-runtime](https://github.com/jsx-eslint/eslint-plugin-react/blob/c8917b0885094b5e4cc2a6f613f7fb6f16fe932e/index.js#L163-L176) in your eslint config (add "plugin:react/jsx-runtime" to "extends") to disable the relevant rules.

[Источник](https://www.npmjs.com/package/eslint-plugin-react)