### PR TITLE
fix(files paths): search files pattern

### DIFF
--- a/configs/sonarjs.js
+++ b/configs/sonarjs.js
@@ -18,7 +18,7 @@ module.exports = {
     },
     overrides: [
         {
-            files: ['*{spec, test, tests}.*', '**/__tests__/**', '**/__stories__/**', '**/__fixtures__/**'],
+            files: ['**/*.{spec,test,tests}.*', '**/__tests__/**', '**/__stories__/**', '**/__fixtures__/**'],
             rules: {
                 'sonarjs/no-duplicate-string': 'off',
                 'sonarjs/no-identical-functions': 'off'

--- a/jest-style-frontend.js
+++ b/jest-style-frontend.js
@@ -1,7 +1,7 @@
 module.exports = {
     overrides: [
         {
-            files: ['*{spec, test, tests}.*', '**/__tests__/**'],
+            files: ['**/*.{spec,test,tests}.*', '**/__tests__/**'],
             rules: {
                 // eslint-plugin-jest Rules
                 'jest/consistent-test-it': [

--- a/jest.js
+++ b/jest.js
@@ -1,7 +1,7 @@
 module.exports = {
     overrides: [
         {
-            files: ['*{spec, test, tests}.*', '**/__tests__/**'],
+            files: ['**/*.{spec,test,tests}.*', '**/__tests__/**'],
             extends: ['plugin:jest/recommended'],
             env: {
                 'jest/globals': true

--- a/node.js
+++ b/node.js
@@ -31,7 +31,7 @@ module.exports = {
             }
         },
         {
-            files: ['*{spec, test, tests}.*', '**/__tests__/**', '**/test/**'],
+            files: ['**/*.{spec,test,tests}.*', '**/__tests__/**', '**/test/**'],
             rules: {
                 // eslint-plugin-n Stylistic Issues
                 'n/no-sync': 'off' // allow sync methods in tests, e.g. when use factory.ts

--- a/typescript.js
+++ b/typescript.js
@@ -88,7 +88,7 @@ module.exports = {
             }
         },
         {
-            files: ['*{spec, test, tests, stories}.*', '**/__tests__/**', '**/__stories__/**'],
+            files: ['**/*.{spec,test,tests,stories}.*', '**/__tests__/**', '**/__stories__/**'],
             rules: {
                 '@typescript-eslint/unbound-method': 'off'
             }


### PR DESCRIPTION
Поправил паттерн поиска файлов, иначе из-за наличия пробелов совсем не искалось

Пример кейсов, которые не работали:
1. Не ищет файлы по пути `[rootProject]/my.tests.ts`
2. Часть маски - `{spec, test, tests}` - в принципе некорректна из-за пробелов. К примеру, тот же файл "`[rootProject]/my.tests.ts` не будет находиться, но уже по этой причине

Fix https://github.com/Byndyusoft/eslint-config/issues/46